### PR TITLE
Add ProVisE: Show, Don't Tell — Evaluating Spatial Cognition in Generative Pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Maintainers can use the [arXiv candidate pipeline](docs/arxiv-pipeline.md) to di
 
 ---
 ## Datasets & Benchmarks & Evaluation
+* **ProVisE**: "Show, Don't Tell: Evaluating Spatial Cognition in Generative Pixels Rather Than LLM Text", **`arxiv 2026.07`**. [[Paper](https://arxiv.org/abs/2607.21072)] [[Code](https://github.com/ZJU-OmniAI/ProVisE)] [[Website](https://zju-omniai.github.io/ProVisE/)]
 * **KineBench**: "KineBench: Benchmarking Embodied World Models via IDM-Free Kinematic Grounding", **`arxiv 2026.07`**. [[Paper](https://arxiv.org/abs/2607.19876)]
 * **WorldRoamBench**: "WorldRoamBench: An Open-World Benchmark for Long-Horizon Stability of Interactive World Models", **`arxiv 2026.06`**. [[Paper](https://arxiv.org/abs/2606.31672)]
 * "A Physics-Grounded Benchmark for Multi-Agent Dynamics in World Models", **`arxiv 2026.06`**. [[Paper](https://arxiv.org/abs/2606.28757)]


### PR DESCRIPTION
Hi, thanks for maintaining this comprehensive list!

This PR adds our recent work to **Datasets & Benchmarks & Evaluation** (newest-first, following the existing entry format):

**Show, Don't Tell: Evaluating Spatial Cognition in Generative Pixels Rather Than LLM Text** (ProVisE)
- Paper: https://arxiv.org/abs/2607.21072
- Code: https://github.com/ZJU-OmniAI/ProVisE
- Project page: https://zju-omniai.github.io/ProVisE/

ProVisE is a benchmark-agnostic framework that elicits protocol-constrained visual answers (pointing, marking, drawing) from image-generation models and parses them into structured predictions compatible with original metrics — enabling image-generation models and text-output VLMs to be evaluated under the same spatial task semantics. It also introduces **SpatialGen-Bench**, a diagnostic benchmark of 470 samples across 14 spatial subtasks and four capability levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ecRPVPjWS3SK42jELrgBT