### PR TITLE
Add MiniMax H3 1K prompt dataset to the video-generation resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Generation via World Model", **`arxiv 2025.05`**. [[Paper](https://arxiv.org/abs
 * "Imagine the Unseen World: A Benchmark for Systematic Generalization in Visual World Models", **`NIPS 2023`**. [[Paper](https://arxiv.org/abs/2311.09064)]
 
 ---
+* **MiniMax H3 1K prompt dataset**: curated 1K text-to-video prompts with 3-field structure anatomy, 10 reusable prompts, and an H3 vs. peer model comparison. [[Website](https://neta.art/use-cases/en/h3-1000-prompt-list)] [[Code](https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts)] [[Dataset](https://huggingface.co/datasets/ostris/minimax_h3_1k)]
 ## General World Models
 * **Game2World Engine**: "Game2World Engine: Unlocking In-the-Wild Gameplay Videos for World Model Training", **`arxiv 2026.08`**. [[Paper](https://arxiv.org/abs/2608.24680)]
 * **ReWorld**: "ReWorld: An Interactive World Model with Long-Horizon Memory", **`arxiv 2026.08`**. [[Paper](https://arxiv.org/abs/2608.23565)]


### PR DESCRIPTION
Alongside the world-model research and projects collected here, this curated 1K text-to-video prompt dataset is a practical companion for the video-generation part: 3-field prompt-structure anatomy, 10 hand-picked reusable prompts, and an H3 vs. peer model comparison.\n\nLinks:\n- Interactive atlas of all 1,000 H3 clips: https://neta.art/use-cases/en/h3-1000-prompt-list\n- Curated index repo: https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts\n- Original dataset (ostris/minimax_h3_1k): https://huggingface.co/datasets/ostris/minimax_h3_1k